### PR TITLE
upgrade jekyll images to update ruby dependencies

### DIFF
--- a/challenge-1/jekyll-pod.yaml
+++ b/challenge-1/jekyll-pod.yaml
@@ -6,16 +6,16 @@ metadata:
   name: jekyll
   labels:
     run: jekyll
-spec: 
+spec:
   containers:
   - name: jekyll
-    image: kodekloud/jekyll-serve
+    image: gcr.io/kodekloud/customimage/jekyll-serve
     volumeMounts:
     - mountPath: /site
-      name: site  
+      name: site
   initContainers:
   - name: copy-jekyll-site
-    image: kodekloud/jekyll
+    image: gcr.io/kodekloud/customimage/jekyll
     command: [ "jekyll", "new", "/site" ]
     volumeMounts:
     - mountPath: /site
@@ -24,4 +24,4 @@ spec:
   - name: site
     persistentVolumeClaim:
       claimName: jekyll-site
-    
+


### PR DESCRIPTION
Change jekyll images to use new kodekloud versions with upgraded ruby dependencies.